### PR TITLE
Add consistency between if and else

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -22,7 +22,7 @@ function removeQuotes(string) {
 
 function formatValue(string) {
     var s = string.trim();
-    if (isNaN(parseInt(s))) {
+    if (isNaN(Number(s))) {
         var se = void 0;
         if (se = /^{((.*|\s)*)}$/.exec(s)) {
             return se[1].split(',').map(function (i) {


### PR DESCRIPTION
```
> parseInt('85529E70-FBF4-48D7-8FBB-AB7740CD194E')
85529
> Number('85529E70-FBF4-48D7-8FBB-AB7740CD194E')
NaN
```

Fixes #1 