### PR TITLE
Update binary to use path from `WHERE WMIC` command

### DIFF
--- a/lib/wmic.js
+++ b/lib/wmic.js
@@ -62,7 +62,7 @@ var defaultOptions = {
     namespace: null,
     privileges: null,
 
-    binary: 'wmic',
+    binary: execSync('WHERE WMIC').toString().trim(),
     encoding: null
 };
 


### PR DESCRIPTION
I kept on getting an error saying that `wmic is not a recognized internal or external command` on some computers, so solve this, I used execSync and the command `WHERE WMIC` to get the path to WMIC instead of relying on environmental variables.